### PR TITLE
Fix Github Actions Workflow Failures

### DIFF
--- a/.github/workflows/discover-repositories.yml
+++ b/.github/workflows/discover-repositories.yml
@@ -155,7 +155,7 @@ jobs:
         # Update a limited number of existing repositories (5 per run to avoid timeouts)
         python3 update_upstream_repos.py \
           --github-token "$GITHUB_TOKEN" \
-          --base-path "../../.." \
+          --base-path "../.." \
           --limit 5 || echo "⚠️ Some upstream updates failed, continuing..."
         
         echo ""
@@ -197,7 +197,7 @@ jobs:
         # Enhanced integration with explicit checks for existing content
         python3 integrate_repositories.py \
           --new-repos "filtered_new_repos.csv" \
-          --base-path "../../.." \
+          --base-path "../.." \
           --update-collection
 
         # Additional organization and README creation

--- a/z.repo_support/scripts/integrate_repositories.py
+++ b/z.repo_support/scripts/integrate_repositories.py
@@ -66,7 +66,8 @@ class RepositoryIntegrator:
             # Filter out None keys and ensure all keys are strings
             valid_keys = [k for k in repo.keys() if k is not None and isinstance(k, str)]
             fieldnames.update(valid_keys)
-        fieldnames = sorted(fieldnames)
+        fieldnames.discard(None)
+        fieldnames = sorted(list(fieldnames))
         
         with open(filepath, 'w', newline='', encoding='utf-8') as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)


### PR DESCRIPTION
This PR fixes issues in the automated repository discovery workflow.

### Issues fixed:
1. `z.repo_support/scripts/integrate_repositories.py` crashing with a TypeError (`'<' not supported between instances of 'str' and 'NoneType'`) when preparing CSV `fieldnames` for headers due to `None` keys being accidentally included when iterating sets of dictionary keys. Fixed by proactively filtering them out using `.discard(None)`.
2. `.github/workflows/discover-repositories.yml` incorrectly setting `--base-path="../../.."` which attempts to escape the root directory of the repository causing a Permission Denied error upon integration. Since the workflow commands are executed from `z.repo_support/scripts/`, the proper offset is `../..` to get to the root of the project.

---
*PR created automatically by Jules for task [3330456936485674988](https://jules.google.com/task/3330456936485674988) started by @GhostwheeI*