### PR TITLE
Fix relative base paths in repository discovery scripts

### DIFF
--- a/z.repo_support/scripts/organize_and_readme.py
+++ b/z.repo_support/scripts/organize_and_readme.py
@@ -12,7 +12,7 @@ from pathlib import Path
 print('🔧 Post-integration organization and README verification...')
 
 # Load the filtered repositories
-base_path = Path('../../../')
+base_path = Path('../../')
 filtered_file = 'filtered_new_repos.csv'
 
 if not os.path.exists(filtered_file):

--- a/z.repo_support/scripts/prefilter_discoveries.py
+++ b/z.repo_support/scripts/prefilter_discoveries.py
@@ -43,7 +43,7 @@ else:
     print('No existing repository database found')
 
 # Check for existing directories/scripts
-base_path = Path('../../../')
+base_path = Path('../../')
 existing_dirs = set()
 
 # Scan existing directory structure

--- a/z.repo_support/scripts/validate_organization.py
+++ b/z.repo_support/scripts/validate_organization.py
@@ -27,7 +27,7 @@ if not new_repos:
     print('No repositories in filtered file')
     exit(0)
 
-base_path = Path('../../../')
+base_path = Path('../../')
 validation_errors = []
 validation_success = []
 


### PR DESCRIPTION
Changed the base_path resolution from `../../../` to `../../` in `organize_and_readme.py`, `prefilter_discoveries.py`, and `validate_organization.py` to correctly target the repository root when these scripts are run from the `z.repo_support/scripts/` directory.

This fixes permission denied errors that were occurring in the GitHub Actions automation.

---
*PR created automatically by Jules for task [6900552806864573353](https://jules.google.com/task/6900552806864573353) started by @GhostwheeI*